### PR TITLE
Snake case `config.toml` fields

### DIFF
--- a/languages/java/config.toml
+++ b/languages/java/config.toml
@@ -1,8 +1,8 @@
 name = "Java"
 grammar = "java"
-pathSuffixes = ["java"]
-lineComments = ["// "]
-autoCloseBefore = ";:.,=}])>` \n\t\""
+path_suffixes = ["java"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>` \n\t\""
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
I noticed that the extension won't properly load, and that due to the `config.toml` containing camelCase fields rather than snake_case.

With these updates the language is loaded automatically when opening a `.java` file, and line comments properly toggled via shortcut. I haven't tried the `autoclose_before` as I'm not yet 100% sure what's the expected behaviour there. 😅